### PR TITLE
add gil support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use pyo3::prelude::*;
 /// A Python module implemented in Rust.
 #[pymodule]
 fn textual_speedups(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.gil_used(false)?;
     // m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     m.add_class::<geometry::GeometryOffset>()?;
     m.add_class::<geometry::Size>()?;


### PR DESCRIPTION
super super super simple pr, prevents this error
```
<frozen importlib._bootstrap>:488: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'textual_speedups.textual_speedups', which has not declared that it can run safely without
the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
```
from happening if you use free threaded python.